### PR TITLE
use correct path in case of autowebp

### DIFF
--- a/thumbor_aws/result_storages/s3_storage.py
+++ b/thumbor_aws/result_storages/s3_storage.py
@@ -15,6 +15,11 @@ from dateutil.parser import parse as parse_ts
 
 class Storage(BaseStorage):
 
+    @property
+    def is_auto_webp(self):
+        return self.context.config.AUTO_WEBP and self.context.request.accepts_webp
+
+
     def __init__(self, context):
         BaseStorage.__init__(self, context)
         self.storage = self.__get_s3_bucket()
@@ -52,7 +57,10 @@ class Storage(BaseStorage):
         return file_key.read()
 
     def normalize_path(self, path):
-        digest = hashlib.sha1(path.encode('utf-8')).hexdigest()
+        path_segments = [path]
+        if self.is_auto_webp:
+            path_segments.append("webp")
+        digest = hashlib.sha1(".".join(path_segments).encode('utf-8')).hexdigest()
         return "thumbor/result_storage/"+digest
 
     def is_expired(self, key):


### PR DESCRIPTION
if autowebp is enabled and detected the result path has to be different from the case when it wasn't detected.

I modified normalize_path in the same sense as https://github.com/thumbor/thumbor/blob/master/thumbor/result_storages/file_storage.py was changed with https://github.com/thumbor/thumbor/commit/ae9a150e8a2b771dd49b4137186e9fdfbea09733#diff-9c717a8aed3280d5be3ffc22fefbc5cf
