### PR TITLE
Added option to use http_loader in mix with s3_loader

### DIFF
--- a/thumbor_aws/loaders/s3_loader.py
+++ b/thumbor_aws/loaders/s3_loader.py
@@ -5,6 +5,7 @@ from boto.s3.key import Key
 import urllib2
 
 import thumbor_aws.connection
+import thumbor.loaders.http_loader as http_loader
 
 def _get_bucket(url):
     """
@@ -30,7 +31,12 @@ def _validate_bucket(context,bucket):
 
 
 def load(context, url, callback):
+    if (context.config.AWS_ENABLE_HTTP_LOADER and 
+      'http' in url):
+        return http_loader.load(context, url, callback)
+      
     url = urllib2.unquote(url)
+    
     if context.config.S3_LOADER_BUCKET:
         bucket = context.config.S3_LOADER_BUCKET
     else:


### PR DESCRIPTION
Add AWS_ENABLE_HTTP_LOADER to thumbor config to allow simultaneous usage of both S3 files and http urls.
That's handy in some situations. E.g. you can load your watermarks from some url and images from S3:
http://your-thumbor.com/unsafe/filters:watermark(http://example.com/watermark.png,0,0,50)/s3_bucket/photo.jpg