### PR TITLE
Fix for ``'str' object has no attribute 'last_modified'``

### DIFF
--- a/thumbor_aws/storages/s3_storage.py
+++ b/thumbor_aws/storages/s3_storage.py
@@ -106,7 +106,7 @@ class Storage(BaseStorage):
 
         file_key = self.storage.get_key(path)
 
-        if not file_key or self.is_expired(path):
+        if not file_key or self.is_expired(file_key):
             return None
 
         return loads(file_key.read())


### PR DESCRIPTION
This bug is causing Thumbor to 500 with the following error:

```
AttributeError: 'str' object has no attribute 'last_modified'
```

Fix is to pass in file_key object instead of the raw path, which is a string.
